### PR TITLE
Add statsig header to API

### DIFF
--- a/app.py
+++ b/app.py
@@ -144,7 +144,9 @@ DEFAULT_HEADERS = {
     'Sec-Fetch-Dest': 'empty',
     'Sec-Fetch-Mode': 'cors',
     'Sec-Fetch-Site': 'same-origin',
-    'Baggage': 'sentry-public_key=b311e0f2690c81f25e2c4cf6d4f7ce1c'
+    'Baggage': 'sentry-public_key=b311e0f2690c81f25e2c4cf6d4f7ce1c',
+    'x-statsig-id': 'PLACEHOLDER_STATSIG_ID',
+    'x-xai-request-id': str(uuid.uuid4())
 }
 
 class AuthTokenManager:


### PR DESCRIPTION
## Summary
- add x-statsig-id and x-xai-request-id fields to DEFAULT_HEADERS

## Testing
- `python3 -m py_compile app.py`
